### PR TITLE
Do not throw errors in case the stream was canceled

### DIFF
--- a/src/main/java/com/exacaster/deltafetch/Application.java
+++ b/src/main/java/com/exacaster/deltafetch/Application.java
@@ -1,7 +1,6 @@
 package com.exacaster.deltafetch;
 
 import io.micronaut.runtime.Micronaut;
-import java.util.Optional;
 
 public class Application {
     public static void main(String[] args) {

--- a/src/main/java/com/exacaster/deltafetch/search/parquet/readsupport/ParquetIterator.java
+++ b/src/main/java/com/exacaster/deltafetch/search/parquet/readsupport/ParquetIterator.java
@@ -2,6 +2,7 @@ package com.exacaster.deltafetch.search.parquet.readsupport;
 
 import com.google.common.collect.AbstractIterator;
 import java.io.IOException;
+import java.io.InterruptedIOException;
 import org.apache.parquet.hadoop.ParquetReader;
 
 public class ParquetIterator<T> extends AbstractIterator<T> {
@@ -17,6 +18,9 @@ public class ParquetIterator<T> extends AbstractIterator<T> {
         try {
             T record = reader.read();
             return (record == null) ? endOfData() : record;
+        } catch (InterruptedIOException e) {
+            // Stream was cancelled (e.g., limit reached), treat as end of data
+            return endOfData();
         } catch (IOException e) {
             throw new IllegalStateException("Failed reading file", e);
         }


### PR DESCRIPTION
Currently if we reach limit records there is an ERROR level message thrown even though this is expected behaviour and the exception should not be thrown at all.