### PR TITLE
Change to ERROR level logging for Parquet library

### DIFF
--- a/src/main/java/com/exacaster/deltafetch/search/parquet/ParquetLookupReader.java
+++ b/src/main/java/com/exacaster/deltafetch/search/parquet/ParquetLookupReader.java
@@ -16,6 +16,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -43,6 +44,9 @@ public class ParquetLookupReader {
                     LOG.error("Failed to close ParquetReader", e);
                 }
             });
+        } catch (InterruptedIOException e) {
+            LOG.debug("Read interrupted for {}", path);
+            return Stream.empty();
         } catch (IOException e) {
             throw new IllegalStateException("Failed building reader", e);
         }

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -6,6 +6,7 @@
     </appender>
 
     <logger name="org.apache.parquet" level="warn"/>
+    <logger name="org.apache.parquet.hadoop.ColumnIndexStoreImpl" level="error"/>
     <logger name="org.apache.hadoop" level="warn"/>
     <logger name="io.delta.standalone" level="warn"/>
     <logger name="com.exacaster.deltafetch.search" level="debug"/>


### PR DESCRIPTION
Previous [PR](https://github.com/exacaster/delta-fetch/pull/58) did not hide all of the errors.